### PR TITLE
Adds support for envconsul

### DIFF
--- a/.envrc.sample
+++ b/.envrc.sample
@@ -1,0 +1,14 @@
+# see https://www.consul.io/commands#consul_http_addr
+CONSUL_HTTP_ADDR = "..."
+
+# see https://www.consul.io/commands#consul_http_token
+CONSUL_TOKEN = "..."
+
+# see https://www.vaultproject.io/docs/commands#vault_addr
+VAULT_ADDR = "..."
+
+# see https://www.vaultproject.io/docs/commands#vault_token
+VAULT_TOKEN = "..."
+
+# see https://www.vaultproject.io/docs/commands#vault_namespace
+VAULT_NAMESPACE = "..."

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 ### Ansible ###
 *.retry
 
+### direnv ###
+.envrc
+
 ### Packer ###
 *.log
 output-*

--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -5,12 +5,6 @@
     },
     {
       "pattern": "^https://github.com/operatehappy/packer-hashicorp/graphs/contributors"
-    },
-    {
-      "pattern": "^image.pkr.hcl"
-    },
-    {
-      "pattern": "^variables.pkr.hcl"
     }
   ],
   "timeout": "30s",

--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -1,12 +1,4 @@
 {
-  "ignorePatterns": [
-    {
-      "pattern": "^https://github.com/operatehappy/packer-hashicorp/issues"
-    },
-    {
-      "pattern": "^https://github.com/operatehappy/packer-hashicorp/graphs/contributors"
-    }
-  ],
   "timeout": "30s",
   "retryOn429": true
 }

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Ansible is used for system-level operations (e.g.: installing and removing packa
 
 Terraform is used as a helper, only. It is possible (though not advised) to manually create the resources needed.
 
+Direnv is used as a helper to programmatically load environment variables.
+
 ## Usage
 
 This repository contains Packer templates for multiple providers.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 - Packer `1.7.8` or newer
 - Terraform `1.1.3` or newer
 - Ansible `2.12.1` or newer
+- direnv `2.30.3` or newer
 
 Ansible is used for system-level operations (e.g.: installing and removing packages).
 
@@ -97,6 +98,11 @@ The following generic build options are available:
 Disables parallelization and enables debug mode.
 See [here](https://www.packer.io/docs/commands/build#debug) for more information.
 
+### `enable-envconsul`
+
+Enables transparent support for [envconsul](https://github.com/hashicorp/envconsul).
+See [here](#envconsul) for more information.
+
 #### `enable-inspec`
 
 Enable the InSpec Provisioner and image validation against included baselines.
@@ -164,6 +170,14 @@ The authors would like to thank the following parties for their inspiration and 
 * [@ansible-community](https://github.com/ansible-community?q=hashicorp)
 * [Mark Lewis](https://github.com/ml4/base)
 * [Mike Nomitch](https://github.com/glenngillen/nomatic-stack)
+
+### envconsul
+
+To dynamically retrieve environment variables such as provider authentication credentials and region information, [envconsul](https://github.com/hashicorp/envconsul) may be used.
+
+Envconsul expects configuration to be available at [./envconsul.hcl](./envconsul.hcl) and is configured with sane defaults.
+
+To provide connection information and credentials to (HCP) Consul and (HCP) Vault, [direnv](https://direnv.net) may be used. See [./envrc.sample](./envrc.sample) for a sample configuration.
 
 ## Author Information
 

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ To dynamically retrieve environment variables such as provider authentication cr
 
 Envconsul expects configuration to be available at [./envconsul.hcl](./envconsul.hcl) and is configured with sane defaults.
 
-To provide connection information and credentials to (HCP) Consul and (HCP) Vault, [direnv](https://direnv.net) may be used. See [./envrc.sample](./envrc.sample) for a sample configuration.
+To provide connection information and credentials to (HCP) Consul and (HCP) Vault, [direnv](https://direnv.net) may be used. See [./.envrc.sample](./.envrc.sample) for a sample configuration.
 
 ## Author Information
 

--- a/envconsul.hcl
+++ b/envconsul.hcl
@@ -1,0 +1,78 @@
+# for more information on this configuration, run `envconsul -h` or see https://github.com/hashicorp/envconsul#configuration-file
+consul {
+  # Sets the address of the Consul instance
+  # This value should be retrieved from environment variables directly or by loading `.envrc`.
+  #address = "..."
+
+  # Sets the Consul API token
+  # This value should be retrieved from environment variables directly or by loading `.envrc`.
+  #token = "..."
+
+  retry {
+    # Use retry logic when communication with Consul fails
+    enabled = true
+
+    # The number of attempts to use when retrying failed communications
+    attempts = 3
+
+    # The base amount to use for the backoff duration.
+    backoff = "500ms"
+
+    # The maximum limit of the retry backoff duration.
+    max_backoff = "1m"
+  }
+
+  ssl {
+    # Use SSL when connecting to Consul
+    enabled = true
+
+    # Verify certificates when connecting via SSL
+    verify = true
+  }
+}
+
+vault {
+  # Sets the address of the Vault server
+  # This value should be retrieved from environment variables directly or by loading `.envrc`.
+  # address = "..."
+
+  # Sets the Vault namespace
+  # This value should be retrieved from environment variables directly or by loading `.envrc`.
+  # namespace = "..."
+
+  # Sets the Vault API token
+  # This value should be retrieved from environment variables directly or by loading `.envrc`.
+  # token = "..."
+
+  # File to read Vault API token from.
+  # This value should be retrieved from environment variables directly or by loading `.envrc`.
+  # vault_agent_token_file = "..."
+
+  # Unwrap the provided Vault API token
+  unwrap_token = false
+
+  # Periodically renew the provided Vault API token
+  renew_token = false
+
+  retry {
+    # Use retry logic when communication with Consul fails
+    enabled = true
+
+    # The number of attempts to use when retrying failed communications
+    attempts = 3
+
+    # The base amount to use for the backoff duration.
+    backoff = "500ms"
+
+    # The maximum limit of the retry backoff duration.
+    max_backoff = "1m"
+  }
+
+  ssl {
+    # Use SSL when connecting to Consul
+    enabled = true
+
+    # Verify certificates when connecting via SSL
+    verify = true
+  }
+}

--- a/make/commons.mk
+++ b/make/commons.mk
@@ -45,6 +45,12 @@ define print_ansible_version_if_available
 	echo "  * \`ansible\` version: \`"$(if $(shell which ansible),$(shell ansible --version | head -n 1)"\`", "not available")
 endef
 
+# convenience function to pretty-print version information when `envconsul` binary is available
+define print_envconsul_version_if_available
+	# expected output: `envconsul v0.12.1 (265f933)`
+	echo "  * \`envconsul\` version: \`"$(if $(shell which envconsul),$(shell envconsul -once --version)"\`", "not available")
+endef
+
 # convenience function to pretty-print version information when `gcloud` binary is available
 define print_gcloud_version_if_available
 	# expected output: `321.0.0`
@@ -61,6 +67,8 @@ env-info: # Prints Version Information
 
 	# expected output: `Terraform v1.1.1`
 	$(call print_version_if_available,"terraform", "--version")
+
+	$(call print_envconsul_version_if_available)
 
 	$(call print_ansible_version_if_available)
 

--- a/make/helpers.mk
+++ b/make/helpers.mk
@@ -1,7 +1,15 @@
 # configuration
-ansible_playbooks = ./ansible/playbooks
-generated_dir     = ./generated/vagrant
-vagrant_box_name ?= "ubuntu-hashicorp"
+ansible_playbooks  = ./ansible/playbooks
+envconsul_config   = ./envconsul.hcl
+envconsul_loglevel = trace
+generated_dir      = ./generated/vagrant
+vagrant_box_name   ?= "ubuntu-hashicorp"
+
+ifdef enable-envconsul
+envconsul_toggle = envconsul -log-level $(envconsul_loglevel) -config="$(envconsul_config)"
+else
+envconsul_toggle =
+endif
 
 # unsupported helper to remove "generated" directory
 .SILENT .PHONY: _clean

--- a/make/packer.mk
+++ b/make/packer.mk
@@ -102,6 +102,8 @@ endif
 .PHONY: build
 build: # Builds an Image with Packer
 	$(if $(target),,$(call missing_target))
+	$(envconsul_toggle) \
+  \
 	packer \
 		build \
 			$(packer_debug) \

--- a/make/terraform.mk
+++ b/make/terraform.mk
@@ -8,6 +8,8 @@ endif
 .PHONY: terraform-plan
 terraform-plan: # Plans prerequisite resources with Terraform
 	$(if $(target),,$(call missing_target))
+	$(envconsul_toggle) \
+	\
 	terraform \
 		-chdir="./terraform/$(target)" \
 		plan \
@@ -15,6 +17,8 @@ terraform-plan: # Plans prerequisite resources with Terraform
 .PHONY: terraform-apply
 terraform-apply: # Creates prerequisite resources with Terraform
 	$(if $(target),,$(call missing_target))
+	$(envconsul_toggle) \
+	\
 	terraform \
 		-chdir="./terraform/$(target)" \
 		apply \
@@ -23,6 +27,8 @@ terraform-apply: # Creates prerequisite resources with Terraform
 .PHONY: terraform-destroy
 terraform-destroy: # Destroys prerequisite resources with Terraform
 	$(if $(target),,$(call missing_target))
+	$(envconsul_toggle) \
+	\
 	terraform \
 		-chdir="./terraform/$(target)" \
 		destroy \
@@ -31,6 +37,8 @@ terraform-destroy: # Destroys prerequisite resources with Terraform
 .PHONY: terraform-init
 terraform-init: # Initializes Terraform
 	$(if $(target),,$(call missing_target))
+	$(envconsul_toggle) \
+	\
 	terraform \
 		-chdir="./terraform/$(target)" \
 		init \

--- a/packer/azure/image.pkr.hcl
+++ b/packer/azure/image.pkr.hcl
@@ -6,7 +6,7 @@ packer {
   required_plugins {
     # see https://github.com/hashicorp/packer-plugin-azure/releases/
     azure = {
-      version = "1.0.1"
+      version = "1.0.5"
       source  = "github.com/hashicorp/azure"
     }
 


### PR DESCRIPTION
Hello maintainers! :wave:

This PR introduces support for [envconsul](https://github.com/hashicorp/envconsul).

As part of this PR, I am also making these minor changes:

* adds support for `direnv` (and includes a sample configuration for `envconsul`.

## suggested merge message:

```
* Packer
  * bumps Azure plugin from `1.0.1` to `1.0.5` (a remnant of #23)

* Make
  * adds `enable-envconsul` toggle
  * adds `envconsul` support for `build` targets
  * adds `envconsul` support for `terraform-plan`, `terraform-apply`, `terraform-destroy` and `terraform-init` targets

* Documentation
  * updates documentation for `envconsul`
```
